### PR TITLE
Add web dashboard for curated job links

### DIFF
--- a/assets/job-links.js
+++ b/assets/job-links.js
@@ -1,0 +1,148 @@
+window.jobLinksLastUpdated = "22 September 2025";
+
+window.jobLinks = [
+  {
+    title: "Seek – Power BI roles in Sydney",
+    url: "https://www.seek.com.au/power-bi-jobs/in-All-Sydney-NSW",
+    locations: ["Sydney"],
+    resume: "Data Analyst CV",
+    summary:
+      "Start here for Power BI and analytics contracts across Sydney. Mention the polygon.io + Azure Maps dashboards and your Jenkins/Redis automation POC to stand out.",
+    focusAreas: ["Power BI Premium", "API integrations", "Automation"],
+  },
+  {
+    title: "LinkedIn – Business Intelligence & Data Analyst jobs (Sydney, last 7 days)",
+    url: "https://www.linkedin.com/jobs/search/?keywords=Power%20BI%20Analyst&location=Sydney%2C%20New%20South%20Wales%2C%20Australia&f_TPR=r604800",
+    locations: ["Sydney"],
+    resume: "Data Analyst CV",
+    summary:
+      "Use this filter daily for fresh BI analyst openings. Lead with the $1M Transport for NSW grant win and rapid Power BI Premium releases.",
+    focusAreas: ["Stakeholder management", "Power BI", "ROI storytelling"],
+  },
+  {
+    title: "Indeed – Data analyst & Power BI roles in Sydney (posted in 7 days)",
+    url: "https://au.indeed.com/jobs?q=data+analyst+power+bi&l=Sydney+NSW&fromage=7",
+    locations: ["Sydney"],
+    resume: "Data Analyst CV",
+    summary:
+      "Sort by date to quickly message hiring managers. Reference the $250K Excel automation savings and 10% testing cost reduction in your outreach.",
+    focusAreas: ["Cost savings", "Process automation", "Python"],
+  },
+  {
+    title: "Seek – CRM & Customer Analytics openings (Sydney)",
+    url: "https://www.seek.com.au/crm-analyst-jobs/in-All-Sydney-NSW",
+    locations: ["Sydney"],
+    resume: "Data Analyst CV",
+    summary:
+      "Great for customer analytics teams that need Salesforce governance. Highlight Exact CRM pipeline stewardship and Power Automate flows.",
+    focusAreas: ["Salesforce", "Customer analytics", "Power Automate"],
+  },
+  {
+    title: "LinkedIn – Sales Development Representative roles (Sydney, last 7 days)",
+    url: "https://www.linkedin.com/jobs/search/?keywords=Sales%20Development%20Representative&location=Sydney%2C%20New%20South%20Wales%2C%20Australia&f_TPR=r604800",
+    locations: ["Sydney"],
+    resume: "Sales Representative CV",
+    summary:
+      "Target SaaS and fintech SDR openings. Talk about your 20–30 daily calls, 40% meeting show-rate, and compliance-grade scripting.",
+    focusAreas: ["Outbound prospecting", "Salesforce", "Conversion rate"],
+  },
+  {
+    title: "Seek – Customer success & service team lead roles (Sydney)",
+    url: "https://www.seek.com.au/customer-service-team-leader-jobs/in-All-Sydney-NSW",
+    locations: ["Sydney"],
+    resume: "Customer Service CV",
+    summary:
+      "Ideal when the job leans into CX leadership. Reference high-NPS call handling, escalation management, and your automation that reduced manual effort.",
+    focusAreas: ["Customer experience", "Escalation management", "Automation"],
+  },
+  {
+    title: "Seek – Test & QA analyst roles (Sydney)",
+    url: "https://www.seek.com.au/test-analyst-jobs/in-All-Sydney-NSW",
+    locations: ["Sydney"],
+    resume: "IT Support CV",
+    summary:
+      "Pursue QA automation teams here. Lead with Python/Selenium scripts, defect-reduction metrics, and governance improvements.",
+    focusAreas: ["QA automation", "Python", "Risk reduction"],
+  },
+  {
+    title: "LinkedIn – Remote-friendly data analyst jobs across APAC",
+    url: "https://www.linkedin.com/jobs/search/?keywords=Data%20Analyst&location=Asia-Pacific&f_TPR=r604800&f_WT=2",
+    locations: ["Remote", "APAC"],
+    resume: "Data Analyst CV",
+    summary:
+      "Covers async-friendly teams across APAC. Stress your GitHub Enterprise delivery cadence and ability to collaborate via automation workflows.",
+    focusAreas: ["Async collaboration", "GitHub Enterprise", "Automation"],
+  },
+  {
+    title: "Seek – Power BI roles in Melbourne",
+    url: "https://www.seek.com.au/power-bi-jobs/in-All-Melbourne-VIC",
+    locations: ["Melbourne"],
+    resume: "Data Analyst CV",
+    summary:
+      "Monitor this daily for Victoria analytics teams. Bring up your Power BI Premium rollouts and polygon.io market intelligence dashboards.",
+    focusAreas: ["Power BI", "Data storytelling", "Dashboards"],
+  },
+  {
+    title: "LinkedIn – Business Intelligence & Data Analyst jobs (Melbourne, last 7 days)",
+    url: "https://www.linkedin.com/jobs/search/?keywords=Power%20BI%20Analyst&location=Melbourne%2C%20Victoria%2C%20Australia&f_TPR=r604800",
+    locations: ["Melbourne"],
+    resume: "Data Analyst CV",
+    summary:
+      "Catch BI postings from tech and utilities companies. Lead with grant funding wins and rapid prototyping skills.",
+    focusAreas: ["Power BI", "Rapid prototyping", "Stakeholder management"],
+  },
+  {
+    title: "Indeed – Data analyst & Power BI roles in Melbourne (posted in 7 days)",
+    url: "https://au.indeed.com/jobs?q=data+analyst+power+bi&l=Melbourne+VIC&fromage=7",
+    locations: ["Melbourne"],
+    resume: "Data Analyst CV",
+    summary:
+      "Sort by date for fast outreach to Victorian employers. Mention the $250K cost savings and testing-efficiency gains up front.",
+    focusAreas: ["Cost optimisation", "Process improvement", "Power BI"],
+  },
+  {
+    title: "Seek – CRM & Customer Analytics openings (Melbourne)",
+    url: "https://www.seek.com.au/crm-analyst-jobs/in-All-Melbourne-VIC",
+    locations: ["Melbourne"],
+    resume: "Data Analyst CV",
+    summary:
+      "Pair analytics with customer lifecycle projects. Highlight Salesforce validation rules, Power Automate flows, and stakeholder workshops.",
+    focusAreas: ["Salesforce", "Customer lifecycle", "Workshops"],
+  },
+  {
+    title: "Seek – Sales Development Representative roles (Melbourne)",
+    url: "https://www.seek.com.au/sales-development-representative-jobs/in-All-Melbourne-VIC",
+    locations: ["Melbourne"],
+    resume: "Sales Representative CV",
+    summary:
+      "Cover Victorian SaaS and tech-enabled sales teams. Reference daily activity volume, conversion rates, and compliance-ready scripts.",
+    focusAreas: ["Pipeline generation", "Salesforce", "Conversion rate"],
+  },
+  {
+    title: "Seek – Customer success & service team lead roles (Melbourne)",
+    url: "https://www.seek.com.au/customer-service-team-leader-jobs/in-All-Melbourne-VIC",
+    locations: ["Melbourne"],
+    resume: "Customer Service CV",
+    summary:
+      "Great for Melbourne CX orgs. Emphasise NPS improvements, issue-resolution speed, and process automation.",
+    focusAreas: ["Customer loyalty", "Process automation", "Coaching"],
+  },
+  {
+    title: "LinkedIn – Global remote SDR & BDR roles (last 7 days)",
+    url: "https://www.linkedin.com/jobs/search/?keywords=Sales%20Development%20Representative&location=Worldwide&f_WT=2&f_TPR=r604800",
+    locations: ["Remote", "Global"],
+    resume: "Sales Representative CV",
+    summary:
+      "Scan this for worldwide SaaS SDR posts. Highlight your video prospecting, conversion metrics, and Salesforce hygiene.",
+    focusAreas: ["Outbound", "Video prospecting", "Global SaaS"],
+  },
+  {
+    title: "LinkedIn – Remote customer success manager roles (worldwide, last 7 days)",
+    url: "https://www.linkedin.com/jobs/search/?keywords=Customer%20Success%20Manager&location=Worldwide&f_WT=2&f_TPR=r604800",
+    locations: ["Remote", "Global"],
+    resume: "Customer Service CV",
+    summary:
+      "Track customer success teams hiring remotely. Stress escalation handling, NPS gains, and automation that removed manual workloads.",
+    focusAreas: ["Customer retention", "Escalations", "Automation"],
+  },
+];

--- a/assets/script.js
+++ b/assets/script.js
@@ -1,0 +1,130 @@
+(() => {
+  const jobListEl = document.getElementById('job-list');
+  const resultsMetaEl = document.getElementById('results-meta');
+  const filterButtons = document.querySelectorAll('[data-filter]');
+  const searchInput = document.getElementById('search');
+  const lastUpdatedEl = document.getElementById('last-updated');
+
+  const jobLinks = Array.isArray(window.jobLinks) ? window.jobLinks : [];
+  const lastUpdated = window.jobLinksLastUpdated;
+
+  if (lastUpdatedEl && lastUpdated) {
+    lastUpdatedEl.textContent = lastUpdated;
+  }
+
+  let currentFilter = 'all';
+  let searchTerm = '';
+  let searchTermDisplay = '';
+
+  const normalise = (value) => (value || '').toString().toLowerCase();
+
+  const matchesFilter = (job) => {
+    if (currentFilter === 'all') {
+      return true;
+    }
+    return (job.locations || []).some((location) => location === currentFilter);
+  };
+
+  const matchesSearch = (job) => {
+    if (!searchTerm) {
+      return true;
+    }
+
+    const haystack = [
+      job.title,
+      job.summary,
+      job.resume,
+      ...(job.focusAreas || []),
+      ...(job.locations || []),
+    ]
+      .filter(Boolean)
+      .map((value) => normalise(value))
+      .join(' ');
+
+    return haystack.includes(searchTerm);
+  };
+
+  const createCard = (job) => {
+    const locationBadges = (job.locations || [])
+      .map((location) => `<span class="badge badge--location">${location}</span>`)
+      .join('');
+
+    const focusBadges = (job.focusAreas || [])
+      .map((focus) => `<span class="badge">${focus}</span>`)
+      .join('');
+
+    return `
+      <article class="job-card">
+        ${locationBadges ? `<div class="job-card__meta">${locationBadges}</div>` : ''}
+        <h3 class="job-card__title">${job.title}</h3>
+        <p class="job-card__summary">${job.summary}</p>
+        <div class="job-card__resume">Recommended résumé <span>${job.resume}</span></div>
+        ${focusBadges ? `<div class="job-card__meta">${focusBadges}</div>` : ''}
+        <a class="job-card__cta" href="${job.url}" target="_blank" rel="noopener noreferrer">Open search</a>
+      </article>
+    `;
+  };
+
+  const updateResultsMeta = (visibleCount) => {
+    if (!resultsMetaEl) return;
+    const total = jobLinks.length;
+    const filterLabel =
+      currentFilter === 'all'
+        ? 'all locations'
+        : `${currentFilter} roles`;
+
+    const searchLabel = searchTerm
+      ? ` matching “${searchTermDisplay}”`
+      : '';
+
+    resultsMetaEl.innerHTML = `<strong>${visibleCount}</strong> of ${total} curated searches shown for ${filterLabel}${searchLabel}.`;
+  };
+
+  const render = () => {
+    const visibleJobs = jobLinks.filter((job) => matchesFilter(job) && matchesSearch(job));
+
+    jobListEl.setAttribute('aria-busy', 'false');
+
+    if (!visibleJobs.length) {
+      jobListEl.innerHTML =
+        '<p class="empty-state">No job links match your filters yet. Try switching locations or adjusting keywords.</p>';
+      updateResultsMeta(0);
+      return;
+    }
+
+    jobListEl.innerHTML = visibleJobs.map((job) => createCard(job)).join('');
+    updateResultsMeta(visibleJobs.length);
+  };
+
+  filterButtons.forEach((button) => {
+    button.addEventListener('click', () => {
+      const selectedFilter = button.dataset.filter;
+      if (!selectedFilter || selectedFilter === currentFilter) {
+        return;
+      }
+
+      currentFilter = selectedFilter;
+
+      filterButtons.forEach((btn) => {
+        const isActive = btn === button;
+        btn.classList.toggle('is-active', isActive);
+        btn.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+      });
+
+      render();
+    });
+
+    button.setAttribute('aria-pressed', button.classList.contains('is-active') ? 'true' : 'false');
+  });
+
+  if (searchInput) {
+    searchInput.addEventListener('input', (event) => {
+      const value = (event.target.value || '').trim();
+      searchTermDisplay = value;
+      searchTerm = value.toLowerCase();
+      render();
+    });
+  }
+
+  render();
+})();

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1,0 +1,383 @@
+:root {
+  color-scheme: light dark;
+  font-family: 'Inter', system-ui, -apple-system, BlinkMacSystemFont, 'Segoe UI',
+    sans-serif;
+  --max-width: min(1100px, 92vw);
+  --radius-lg: 18px;
+  --radius-md: 12px;
+  --surface: #ffffff;
+  --surface-alt: #f4f7fb;
+  --text-primary: #19202c;
+  --text-muted: #475569;
+  --accent: #2563eb;
+  --accent-soft: rgba(37, 99, 235, 0.12);
+  --accent-strong: rgba(37, 99, 235, 0.65);
+  --border: rgba(15, 23, 42, 0.08);
+  --shadow:
+    0 12px 32px rgba(15, 23, 42, 0.08),
+    0 4px 12px rgba(15, 23, 42, 0.06);
+  background-color: var(--surface-alt);
+}
+
+body {
+  margin: 0;
+  font-family: inherit;
+  background: radial-gradient(circle at 15% 20%, #eff6ff 0%, #f8fafc 55%, #f1f5f9 100%);
+  color: var(--text-primary);
+  min-height: 100vh;
+  display: flex;
+  flex-direction: column;
+}
+
+a {
+  color: var(--accent);
+  text-decoration: none;
+}
+
+a:hover,
+a:focus {
+  text-decoration: underline;
+}
+
+.hero {
+  padding: 4.5rem 0 3rem;
+  background: linear-gradient(135deg, #1d4ed8, #312e81 70%);
+  color: #f8fafc;
+}
+
+.hero__content {
+  width: var(--max-width);
+  margin: 0 auto 2.5rem;
+}
+
+.hero__eyebrow {
+  text-transform: uppercase;
+  letter-spacing: 0.18em;
+  font-size: 0.75rem;
+  font-weight: 600;
+  margin: 0 0 0.75rem;
+  opacity: 0.8;
+}
+
+.hero h1 {
+  font-size: clamp(2.25rem, 4vw, 3.25rem);
+  margin: 0 0 1rem;
+  font-weight: 700;
+}
+
+.hero__subtitle {
+  margin: 0;
+  font-size: clamp(1rem, 1.4vw, 1.125rem);
+  line-height: 1.7;
+  max-width: 680px;
+  color: rgba(248, 250, 252, 0.9);
+}
+
+.hero__meta {
+  margin-top: 1.5rem;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.25rem;
+  font-size: 0.95rem;
+  color: rgba(248, 250, 252, 0.82);
+}
+
+.hero__filters {
+  width: var(--max-width);
+  margin: 0 auto;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.filter-button {
+  background: rgba(255, 255, 255, 0.12);
+  border: 1px solid rgba(255, 255, 255, 0.35);
+  color: #f8fafc;
+  border-radius: 999px;
+  padding: 0.55rem 1.3rem;
+  font-size: 0.95rem;
+  font-weight: 500;
+  cursor: pointer;
+  transition: transform 180ms ease, background 180ms ease, border-color 180ms ease;
+}
+
+.filter-button:hover,
+.filter-button:focus {
+  background: rgba(255, 255, 255, 0.2);
+  transform: translateY(-1px);
+}
+
+.filter-button.is-active {
+  background: #f8fafc;
+  color: #0f172a;
+  border-color: transparent;
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.2);
+}
+
+.layout {
+  width: var(--max-width);
+  margin: -2.5rem auto 0;
+  background: var(--surface);
+  border-radius: var(--radius-lg);
+  box-shadow: var(--shadow);
+  padding: 2.75rem clamp(1.5rem, 4vw, 3rem) 3.5rem;
+  position: relative;
+  z-index: 1;
+}
+
+.controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 2rem;
+  align-items: start;
+  margin-bottom: 2.75rem;
+}
+
+.search {
+  display: flex;
+  flex-direction: column;
+  gap: 0.65rem;
+}
+
+.search__label {
+  font-weight: 600;
+  color: var(--text-muted);
+}
+
+.search input {
+  border: 1px solid var(--border);
+  border-radius: var(--radius-md);
+  padding: 0.75rem 1rem;
+  font-size: 1rem;
+  transition: border-color 160ms ease, box-shadow 160ms ease;
+}
+
+.search input:focus {
+  outline: none;
+  border-color: var(--accent);
+  box-shadow: 0 0 0 4px var(--accent-soft);
+}
+
+.tips {
+  background: var(--surface-alt);
+  border-radius: var(--radius-md);
+  padding: 1.5rem;
+  border: 1px solid rgba(15, 23, 42, 0.05);
+}
+
+.tips h2 {
+  margin-top: 0;
+  font-size: 1.1rem;
+}
+
+.tips ul {
+  margin: 0;
+  padding-left: 1.1rem;
+  display: grid;
+  gap: 0.75rem;
+  color: var(--text-muted);
+  line-height: 1.6;
+}
+
+.job-grid {
+  display: grid;
+  gap: 1.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+}
+
+.results-meta {
+  margin-bottom: 1.5rem;
+  font-size: 0.95rem;
+  color: var(--text-muted);
+}
+
+.results-meta strong {
+  color: var(--text-primary);
+}
+
+.job-card {
+  background: var(--surface-alt);
+  border-radius: var(--radius-md);
+  border: 1px solid rgba(15, 23, 42, 0.05);
+  padding: 1.65rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1.1rem;
+  min-height: 220px;
+  box-shadow: 0 14px 30px rgba(15, 23, 42, 0.06);
+}
+
+.job-card__title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 600;
+  line-height: 1.5;
+}
+
+.job-card__summary {
+  margin: 0;
+  color: var(--text-muted);
+  line-height: 1.6;
+  flex-grow: 1;
+}
+
+.job-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+  font-size: 0.8rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.badge--location {
+  background: rgba(14, 165, 233, 0.16);
+  color: #0f172a;
+}
+
+.job-card__resume {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  font-weight: 600;
+  color: var(--text-primary);
+}
+
+.job-card__resume span {
+  padding: 0.35rem 0.65rem;
+  border-radius: 8px;
+  background: rgba(15, 23, 42, 0.06);
+  font-size: 0.8rem;
+}
+
+.job-card__cta {
+  align-self: flex-start;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.6rem 1rem;
+  border-radius: 10px;
+  background: var(--accent);
+  color: #f8fafc;
+  font-weight: 600;
+  border: none;
+  box-shadow: 0 12px 22px rgba(37, 99, 235, 0.25);
+  transition: transform 160ms ease, box-shadow 160ms ease;
+}
+
+.job-card__cta::after {
+  content: '↗';
+  font-size: 1.1rem;
+  line-height: 1;
+}
+
+.job-card__cta:hover,
+.job-card__cta:focus {
+  transform: translateY(-1px);
+  box-shadow: 0 18px 32px rgba(37, 99, 235, 0.28);
+}
+
+.loading,
+.empty-state {
+  font-size: 1rem;
+  color: var(--text-muted);
+}
+
+.footer {
+  width: var(--max-width);
+  margin: 2.5rem auto 3rem;
+  color: var(--text-muted);
+  font-size: 0.95rem;
+  line-height: 1.6;
+}
+
+@media (max-width: 720px) {
+  .hero {
+    padding: 3.25rem 0 2.5rem;
+  }
+
+  .hero__content {
+    margin-bottom: 2rem;
+  }
+
+  .layout {
+    margin-top: -2rem;
+    padding: 2.25rem 1.2rem 3rem;
+  }
+
+  .job-card {
+    padding: 1.4rem;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --surface: #0f172a;
+    --surface-alt: #111c31;
+    --text-primary: #e2e8f0;
+    --text-muted: #94a3b8;
+    --border: rgba(148, 163, 184, 0.2);
+  }
+
+  body {
+    background: radial-gradient(circle at 15% 20%, #1e293b 0%, #0f172a 55%, #111c31 100%);
+  }
+
+  .hero {
+    background: linear-gradient(135deg, #1e3a8a, #1e40af 70%);
+  }
+
+  .filter-button {
+    background: rgba(15, 23, 42, 0.35);
+    border-color: rgba(148, 163, 184, 0.3);
+  }
+
+  .filter-button.is-active {
+    background: #e2e8f0;
+    color: #0f172a;
+  }
+
+  .tips {
+    background: rgba(15, 23, 42, 0.6);
+    border-color: rgba(148, 163, 184, 0.2);
+  }
+
+  .job-card {
+    background: rgba(15, 23, 42, 0.75);
+    border-color: rgba(148, 163, 184, 0.1);
+    box-shadow: 0 16px 32px rgba(15, 23, 42, 0.3);
+  }
+
+  .job-card__resume span {
+    background: rgba(148, 163, 184, 0.2);
+  }
+
+  .badge {
+    background: rgba(37, 99, 235, 0.2);
+    color: #bfdbfe;
+  }
+
+  .badge--location {
+    background: rgba(14, 165, 233, 0.25);
+    color: #bae6fd;
+  }
+
+  .job-card__cta {
+    color: #e2e8f0;
+  }
+
+  .footer {
+    color: #94a3b8;
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,104 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Job Search Launchpad</title>
+    <link rel="stylesheet" href="assets/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <header class="hero">
+      <div class="hero__content">
+        <p class="hero__eyebrow">Daily starting point</p>
+        <h1>Pathfinder job links</h1>
+        <p class="hero__subtitle">
+          Open the site and jump straight into curated analytics, sales, and
+          customer success searches across Sydney, Melbourne, and global remote
+          teams. Filters keep things tidy, and each card reminds you which CV to
+          lead with and the metrics to spotlight.
+        </p>
+        <div class="hero__meta">
+          <span>Last refreshed: <strong id="last-updated">—</strong></span>
+          <span>Time-saver: add this page to your browser bookmarks bar.</span>
+        </div>
+      </div>
+      <div class="hero__filters" role="toolbar" aria-label="Filter job links by location">
+        <button type="button" class="filter-button is-active" data-filter="all">
+          All locations
+        </button>
+        <button type="button" class="filter-button" data-filter="Sydney">
+          Sydney
+        </button>
+        <button type="button" class="filter-button" data-filter="Melbourne">
+          Melbourne
+        </button>
+        <button type="button" class="filter-button" data-filter="Remote">
+          Remote &amp; hybrid
+        </button>
+      </div>
+    </header>
+
+    <main class="layout">
+      <section class="controls" aria-label="Search and quick tips">
+        <label class="search" for="search">
+          <span class="search__label">Search keywords</span>
+          <input
+            id="search"
+            type="search"
+            name="search"
+            placeholder="Filter by role, skill, or résumé"
+            autocomplete="off"
+          />
+        </label>
+        <aside class="tips">
+          <h2>Résumé &amp; cover-letter focus</h2>
+          <ul>
+            <li>
+              Lead with the <strong>Data Analyst CV</strong> for Power BI, BI, and
+              analytics postings. Mention your <em>$1M grant win</em>, Power BI
+              Premium deployments, and Jenkins/Redis automation.
+            </li>
+            <li>
+              Keep the <strong>Sales Representative CV</strong> ready for SDR and
+              inside-sales roles. Emphasise <em>20–30 calls/day</em>, a
+              <em>10% conversion rate</em>, and Salesforce/Xero mastery.
+            </li>
+            <li>
+              Use the <strong>Customer Service or IT Support CV</strong> for CX,
+              service desk, or QA opportunities. Highlight <em>high-NPS support</em>,
+              Salesforce data hygiene, and automation that reduced manual effort.
+            </li>
+            <li>
+              Reinforce <strong>Power BI Premium, Python, SQL, Power Automate,</strong>
+              and <strong>ServiceNow</strong> to capture ATS keywords across
+              postings.
+            </li>
+          </ul>
+        </aside>
+      </section>
+
+      <div class="results-meta" id="results-meta" aria-live="polite"></div>
+
+      <section class="job-grid" id="job-list" aria-live="polite" aria-busy="true">
+        <p class="loading">Loading job links…</p>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <p>
+        Tip: schedule two 25-minute outreach blocks per weekday and update the
+        résumé bullet that best matches the job focus before applying. This page
+        keeps the latest searches in one place so you can execute fast.
+      </p>
+    </footer>
+
+    <script src="assets/job-links.js"></script>
+    <script src="assets/script.js" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a standalone job-search landing page with filters, search and résumé guidance
- style the page with responsive, theme-aware design tokens and reusable badges
- codify curated Sydney, Melbourne and remote job searches with metadata for the UI to render dynamically

## Testing
- node --check assets/script.js
- node --check assets/job-links.js

------
https://chatgpt.com/codex/tasks/task_e_68d1317ced4c83299f6065fffc25abaa