### PR TITLE
Improve dark mode job summary contrast

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -1412,6 +1412,10 @@ html.dark-mode .job-card {
   box-shadow: 0 16px 32px rgba(15, 23, 42, 0.3);
 }
 
+html.dark-mode .job-card__summary {
+  color: var(--text-primary);
+}
+
 html.dark-mode .resume-viewer {
   background: rgba(15, 23, 42, 0.6);
   border-color: rgba(148, 163, 184, 0.2);


### PR DESCRIPTION
## Summary
- increase the dark mode job-card summary text color to match the title for improved readability

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d2440f35508329849e3964df4cef47