### PR TITLE
Move résumé library to dedicated page

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -36,9 +36,6 @@
   const lastUpdatedEl = document.getElementById('last-updated');
   const resumeListEl = document.getElementById('resume-list');
   const resumeFeedbackEl = document.getElementById('resume-feedback');
-  const resumeContentEl = document.getElementById('resume-content');
-  const resumeToggleButton = document.getElementById('resume-toggle');
-  const resumeSectionEl = document.querySelector('.resume-viewer');
 
   const REFRESH_INTERVAL_MS = 3 * 60 * 60 * 1000;
   const MAX_VISIBLE_JOBS = 20;
@@ -141,48 +138,7 @@
     resumeFeedbackEl.textContent = message;
   };
 
-  const updateResumeToggleState = (isVisible) => {
-    if (!resumeToggleButton) {
-      return;
-    }
-
-    resumeToggleButton.setAttribute('aria-expanded', isVisible ? 'true' : 'false');
-    resumeToggleButton.textContent = isVisible ? 'Hide résumés' : 'Show résumés';
-  };
-
-  const setResumeVisibility = (isVisible) => {
-    if (!resumeContentEl) {
-      updateResumeToggleState(false);
-      return;
-    }
-
-    if (isVisible) {
-      resumeContentEl.removeAttribute('hidden');
-      if (resumeSectionEl) {
-        resumeSectionEl.classList.remove('resume-viewer--collapsed');
-      }
-    } else {
-      resumeContentEl.setAttribute('hidden', '');
-      if (resumeSectionEl) {
-        resumeSectionEl.classList.add('resume-viewer--collapsed');
-      }
-    }
-
-    updateResumeToggleState(isVisible);
-  };
-
-  const toggleResumeVisibility = () => {
-    if (!resumeContentEl) {
-      return;
-    }
-
-    const shouldShow = resumeContentEl.hasAttribute('hidden');
-    setResumeVisibility(shouldShow);
-  };
-
   const openResume = (resumeIdentifier) => {
-    setResumeVisibility(true);
-
     const resume = resumeIndex.find(resumeIdentifier);
 
     if (!resume) {
@@ -258,23 +214,30 @@
         )}</div>`
       : '';
 
+    const resumeIdentifier = resume.id || resume.name;
+    const resumeTarget = resumeIdentifier ? escapeHtml(resumeIdentifier) : '';
+    const titleText = escapeHtml(resume.name || 'Résumé');
+
     const accessibleName = resume.name
       ? `Open the ${resume.name} résumé`
       : 'Open the résumé file';
 
+    const titleContent = resumeTarget
+      ? `<button type="button" class="resume-card__title-trigger" data-resume-target="${resumeTarget}" aria-label="${escapeHtml(
+          accessibleName,
+        )}">${titleText}</button>`
+      : `<span class="resume-card__title-text">${titleText}</span>`;
+
     return `
       <article class="resume-card">
         <header class="resume-card__header">
-          <h3>${escapeHtml(resume.name || 'Résumé')}</h3>
+          <h3 class="resume-card__title">
+            ${titleContent}
+          </h3>
         </header>
         ${focus}
         ${highlightMarkup}
         ${skillsMarkup}
-        <div class="resume-card__actions">
-          ${createResumeButton(resume.id || resume.name, 'Open résumé', {
-            ariaLabel: accessibleName,
-          })}
-        </div>
       </article>
     `;
   };
@@ -292,7 +255,7 @@
     }
 
     resumeListEl.innerHTML = resumeIndex.all.map((resume) => createResumeCard(resume)).join('');
-    showResumeMessage('Select a résumé to open it in a new tab.');
+    showResumeMessage('Click a résumé title to open it in a new tab.');
   };
 
   const createCard = (job) => {
@@ -426,13 +389,6 @@
 
   if (resumeListEl) {
     resumeListEl.addEventListener('click', handleResumeTriggerClick);
-  }
-
-  if (resumeToggleButton) {
-    resumeToggleButton.addEventListener('click', (event) => {
-      event.preventDefault();
-      toggleResumeVisibility();
-    });
   }
 
   window.openResume = openResume;

--- a/assets/styles.css
+++ b/assets/styles.css
@@ -596,42 +596,9 @@ a:focus {
   line-height: 1.6;
 }
 
-.resume-viewer__toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.35rem;
-  padding: 0.5rem 1.1rem;
-  border-radius: 999px;
-  border: 1px solid rgba(37, 99, 235, 0.45);
-  background: var(--surface);
-  color: var(--accent);
-  font-size: 0.9rem;
-  font-weight: 600;
-  cursor: pointer;
-  transition: transform 160ms ease, box-shadow 160ms ease, border-color 160ms ease,
-    background-color 160ms ease, color 160ms ease;
-}
-
-.resume-viewer__toggle:hover,
-.resume-viewer__toggle:focus {
-  border-color: rgba(37, 99, 235, 0.65);
-  background: rgba(37, 99, 235, 0.08);
-  color: #1d4ed8;
-  transform: translateY(-1px);
-}
-
-.resume-viewer__toggle:focus {
-  outline: none;
-  box-shadow: 0 0 0 4px var(--accent-soft);
-}
-
 .resume-viewer__content {
   display: grid;
   gap: 1.5rem;
-}
-
-.resume-viewer--collapsed .resume-viewer__toggle {
-  transform: none;
 }
 
 .resume-viewer__feedback {
@@ -670,9 +637,54 @@ a:focus {
   box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
 }
 
-.resume-card__header h3 {
+.resume-card__title {
   margin: 0;
   font-size: 1.05rem;
+  line-height: 1.3;
+}
+
+.resume-card__title-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0;
+  border: none;
+  background: transparent;
+  font: inherit;
+  color: inherit;
+  cursor: pointer;
+  text-align: left;
+  transition: color 160ms ease, transform 160ms ease;
+}
+
+.resume-card__title-trigger::after {
+  content: '↗';
+  font-size: 0.9rem;
+  line-height: 1;
+  color: var(--text-muted);
+  transition: color 160ms ease, transform 160ms ease;
+}
+
+.resume-card__title-trigger:hover,
+.resume-card__title-trigger:focus {
+  color: var(--accent);
+  transform: translateY(-1px);
+}
+
+.resume-card__title-trigger:hover::after,
+.resume-card__title-trigger:focus::after {
+  color: var(--accent);
+  transform: translateX(2px);
+}
+
+.resume-card__title-trigger:focus {
+  outline: none;
+  box-shadow: 0 0 0 4px var(--accent-soft);
+  border-radius: 6px;
+}
+
+.resume-card__title-text {
+  display: inline-block;
 }
 
 .resume-card__focus {
@@ -696,10 +708,6 @@ a:focus {
   display: flex;
   flex-wrap: wrap;
   gap: 0.45rem;
-}
-
-.resume-card__actions {
-  margin-top: 0.5rem;
 }
 
 .resume-link {
@@ -1279,11 +1287,6 @@ a:focus {
     align-items: stretch;
   }
 
-  .resume-viewer__toggle {
-    width: 100%;
-    justify-content: center;
-  }
-
   .resume-viewer__list {
     grid-template-columns: 1fr;
   }
@@ -1421,23 +1424,24 @@ html.dark-mode .resume-viewer {
   border-color: rgba(148, 163, 184, 0.2);
 }
 
-html.dark-mode .resume-viewer__toggle {
-  background: rgba(148, 163, 184, 0.18);
-  border-color: rgba(148, 163, 184, 0.35);
-  color: #bfdbfe;
-}
-
-html.dark-mode .resume-viewer__toggle:hover,
-html.dark-mode .resume-viewer__toggle:focus {
-  border-color: rgba(148, 163, 184, 0.55);
-  background: rgba(148, 163, 184, 0.3);
-  color: #e0f2fe;
-}
-
 html.dark-mode .resume-card {
   background: rgba(15, 23, 42, 0.75);
   border-color: rgba(148, 163, 184, 0.2);
   box-shadow: 0 18px 34px rgba(15, 23, 42, 0.28);
+}
+
+html.dark-mode .resume-card__title-trigger::after {
+  color: #94a3b8;
+}
+
+html.dark-mode .resume-card__title-trigger:hover,
+html.dark-mode .resume-card__title-trigger:focus {
+  color: #bfdbfe;
+}
+
+html.dark-mode .resume-card__title-trigger:hover::after,
+html.dark-mode .resume-card__title-trigger:focus::after {
+  color: #bfdbfe;
 }
 
 html.dark-mode .resume-link {

--- a/index.html
+++ b/index.html
@@ -33,6 +33,7 @@
           <span>Auto-refreshes every 3 hours to keep the shortlist current.</span>
         </div>
         <div class="hero__actions">
+          <a class="hero__action" href="resumes.html">Open résumé library</a>
           <a class="hero__action" href="cover-letter.html">Open cover-letter studio</a>
           <a
             class="hero__action hero__action--secondary"
@@ -55,43 +56,6 @@
 
       <section class="job-grid" id="job-list" aria-live="polite" aria-busy="true">
         <p class="loading">Loading job links…</p>
-      </section>
-
-      <section
-        class="resume-viewer resume-viewer--collapsed"
-        aria-label="Résumé library"
-      >
-        <header class="resume-viewer__header">
-          <div class="resume-viewer__intro">
-            <h2>Résumé library</h2>
-            <p>
-              Open the version that best matches the job before applying and keep
-              the talking points handy.
-            </p>
-          </div>
-          <button
-            type="button"
-            class="resume-viewer__toggle"
-            id="resume-toggle"
-            aria-expanded="false"
-            aria-controls="resume-content"
-          >
-            Show résumés
-          </button>
-        </header>
-        <div class="resume-viewer__content" id="resume-content" hidden>
-          <p
-            class="resume-viewer__feedback"
-            id="resume-feedback"
-            role="status"
-            aria-live="polite"
-          >
-            Select a résumé to open it in a new tab.
-          </p>
-          <div class="resume-viewer__list" id="resume-list">
-            <p class="resume-viewer__empty">Loading résumé library…</p>
-          </div>
-        </div>
       </section>
     </main>
 

--- a/resumes.html
+++ b/resumes.html
@@ -1,0 +1,87 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Résumé library • Pathfinder</title>
+    <link rel="stylesheet" href="assets/styles.css" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap"
+      rel="stylesheet"
+    />
+  </head>
+  <body>
+    <header class="hero">
+      <div class="hero__content">
+        <p class="hero__eyebrow">Résumé hub</p>
+        <h1>Open the right CV in seconds</h1>
+        <p class="hero__subtitle">
+          Pick the résumé that aligns with the job focus and it will launch in a new tab instantly.
+          Each card highlights the impact points and skills to echo in your application.
+        </p>
+        <div class="hero__actions">
+          <a class="hero__action" href="index.html">Back to job links</a>
+          <a class="hero__action" href="cover-letter.html">Open cover-letter studio</a>
+          <button type="button" class="hero__action theme-toggle" id="theme-toggle" title="Toggle dark mode">
+            <span class="theme-toggle__icon"></span>
+          </button>
+        </div>
+      </div>
+    </header>
+
+    <main class="layout">
+      <section class="resume-viewer" aria-label="Résumé library">
+        <header class="resume-viewer__header">
+          <div class="resume-viewer__intro">
+            <h2>Résumé library</h2>
+            <p>
+              Click any résumé title below to open the document in a new tab. Use the highlights to tailor your
+              talking points before applying.
+            </p>
+          </div>
+        </header>
+        <div class="resume-viewer__content">
+          <p class="resume-viewer__feedback" id="resume-feedback" role="status" aria-live="polite">
+            Loading résumé options…
+          </p>
+          <div class="resume-viewer__list" id="resume-list">
+            <p class="resume-viewer__empty">Loading résumé library…</p>
+          </div>
+        </div>
+      </section>
+    </main>
+
+    <footer class="footer">
+      <section class="tips tips--footer" aria-label="Résumé and cover-letter focus">
+        <h2>Résumé &amp; cover-letter focus</h2>
+        <ul>
+          <li>
+            Lead with the <strong>Data Analyst CV</strong> for Power BI, BI, and analytics postings. Mention your
+            <em>$1M grant win</em>, Power BI Premium deployments, and Jenkins/Redis automation.
+          </li>
+          <li>
+            Keep the <strong>Sales Representative CV</strong> ready for SDR and inside-sales roles. Emphasise
+            <em>20–30 calls/day</em>, a <em>10% conversion rate</em>, and Salesforce/Xero mastery.
+          </li>
+          <li>
+            Use the <strong>Customer Service or IT Support CV</strong> for CX, service desk, or QA opportunities.
+            Highlight <em>high-NPS support</em>, Salesforce data hygiene, and automation that reduced manual effort.
+          </li>
+          <li>
+            Reinforce <strong>Power BI Premium, Python, SQL, Power Automate,</strong> and <strong>ServiceNow</strong>
+            to capture ATS keywords across postings.
+          </li>
+        </ul>
+      </section>
+      <p>
+        Update the résumé bullet that best matches the job focus before applying. This page keeps the latest résumés in
+        one place so you can execute fast.
+      </p>
+    </footer>
+
+    <script src="assets/resumes.js" defer></script>
+    <script src="assets/script.js" defer></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- create a standalone `resumes.html` page that renders the résumé library and guidance
- remove the collapsible résumé viewer from `index.html` and link to the new page
- update scripts and styling so résumé cards open on title click without extra buttons

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d344939d088329b1e606075fcd1597