### PR TITLE
Add linked resource icons for cover letters and résumés

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -93,6 +93,71 @@ a:focus {
   color: rgba(248, 250, 252, 0.82);
 }
 
+.hero__resources {
+  margin-top: 2rem;
+  display: grid;
+  gap: 0.9rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.hero__resource-link {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  padding: 0.95rem 1.2rem;
+  border-radius: 16px;
+  border: 1px solid rgba(224, 231, 255, 0.35);
+  background: rgba(15, 23, 42, 0.35);
+  color: #f8fafc;
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.26);
+  transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease,
+    border-color 160ms ease;
+}
+
+.hero__resource-link:hover,
+.hero__resource-link:focus-visible {
+  text-decoration: none;
+  transform: translateY(-1px);
+  box-shadow: 0 20px 38px rgba(15, 23, 42, 0.32);
+  background: rgba(15, 23, 42, 0.48);
+  border-color: rgba(224, 231, 255, 0.55);
+  outline: none;
+}
+
+.hero__resource-icon {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 48px;
+  height: 48px;
+  border-radius: 14px;
+  background: rgba(30, 64, 175, 0.6);
+  color: #e0e7ff;
+  flex-shrink: 0;
+}
+
+.hero__resource-icon svg {
+  width: 26px;
+  height: 26px;
+}
+
+.hero__resource-info {
+  display: grid;
+  gap: 0.2rem;
+}
+
+.hero__resource-label {
+  font-size: 1rem;
+  font-weight: 600;
+  color: currentColor;
+}
+
+.hero__resource-subtitle {
+  font-size: 0.82rem;
+  color: rgba(248, 250, 252, 0.75);
+  font-weight: 500;
+}
+
 .hero__actions {
   margin-top: 2rem;
   display: flex;
@@ -1354,6 +1419,28 @@ html.dark-mode body {
 
 html.dark-mode .hero {
   background: linear-gradient(135deg, #1e3a8a, #1e40af 70%);
+}
+
+html.dark-mode .hero__resource-link {
+  background: rgba(15, 23, 42, 0.55);
+  border-color: rgba(148, 163, 184, 0.35);
+  color: #e2e8f0;
+  box-shadow: 0 18px 36px rgba(2, 6, 23, 0.6);
+}
+
+html.dark-mode .hero__resource-link:hover,
+html.dark-mode .hero__resource-link:focus-visible {
+  background: rgba(30, 64, 175, 0.62);
+  border-color: rgba(165, 180, 252, 0.65);
+}
+
+html.dark-mode .hero__resource-icon {
+  background: rgba(37, 99, 235, 0.24);
+  color: #c7d2fe;
+}
+
+html.dark-mode .hero__resource-subtitle {
+  color: rgba(226, 232, 240, 0.72);
 }
 
 html.dark-mode .filter-button {

--- a/cover-letter.html
+++ b/cover-letter.html
@@ -23,6 +23,63 @@
           as the draft comes together so you can copy the results straight into
           outreach.
         </p>
+        <div class="hero__resources" aria-label="Quick Pathfinder tools">
+          <a class="hero__resource-link" href="cover-letter.html">
+            <span class="hero__resource-icon" aria-hidden="true">
+              <svg
+                viewBox="0 0 24 24"
+                role="img"
+                aria-hidden="true"
+                focusable="false"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.75"
+              >
+                <path
+                  d="M3.75 6.75h16.5a.75.75 0 0 1 .75.75v9a.75.75 0 0 1-.75.75H3.75A.75.75 0 0 1 3 16.5v-9a.75.75 0 0 1 .75-.75z"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <path
+                  d="M4.5 7.5l7.5 5.25L19.5 7.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </span>
+            <span class="hero__resource-info">
+              <span class="hero__resource-label">Cover-letter studio</span>
+              <span class="hero__resource-subtitle">Draft outreach with résumé context</span>
+            </span>
+          </a>
+          <a class="hero__resource-link" href="resumes.html">
+            <span class="hero__resource-icon" aria-hidden="true">
+              <svg
+                viewBox="0 0 24 24"
+                role="img"
+                aria-hidden="true"
+                focusable="false"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.75"
+              >
+                <path
+                  d="M7.5 3h6l3 3v12.75a1.5 1.5 0 0 1-1.5 1.5H7.5a1.5 1.5 0 0 1-1.5-1.5V4.5A1.5 1.5 0 0 1 7.5 3z"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <path d="M13.5 3v3h3" stroke-linecap="round" stroke-linejoin="round" />
+                <path d="M9 11.25h6" stroke-linecap="round" stroke-linejoin="round" />
+                <path d="M9 14.25h6" stroke-linecap="round" stroke-linejoin="round" />
+                <path d="M9 17.25h3.75" stroke-linecap="round" stroke-linejoin="round" />
+              </svg>
+            </span>
+            <span class="hero__resource-info">
+              <span class="hero__resource-label">Résumé library</span>
+              <span class="hero__resource-subtitle">Open tailored CVs instantly</span>
+            </span>
+          </a>
+        </div>
         <div class="hero__actions">
           <a class="hero__action hero__action--secondary" href="index.html"
             >← Back to job links</a

--- a/index.html
+++ b/index.html
@@ -34,14 +34,71 @@
             >Open the OneDrive shortcuts</a
           >.
         </p>
+        <div class="hero__resources" aria-label="Quick Pathfinder tools">
+          <a class="hero__resource-link" href="cover-letter.html">
+            <span class="hero__resource-icon" aria-hidden="true">
+              <svg
+                viewBox="0 0 24 24"
+                role="img"
+                aria-hidden="true"
+                focusable="false"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.75"
+              >
+                <path
+                  d="M3.75 6.75h16.5a.75.75 0 0 1 .75.75v9a.75.75 0 0 1-.75.75H3.75A.75.75 0 0 1 3 16.5v-9a.75.75 0 0 1 .75-.75z"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <path
+                  d="M4.5 7.5l7.5 5.25L19.5 7.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </span>
+            <span class="hero__resource-info">
+              <span class="hero__resource-label">Cover-letter studio</span>
+              <span class="hero__resource-subtitle">Draft outreach with résumé context</span>
+            </span>
+          </a>
+          <a class="hero__resource-link" href="resumes.html">
+            <span class="hero__resource-icon" aria-hidden="true">
+              <svg
+                viewBox="0 0 24 24"
+                role="img"
+                aria-hidden="true"
+                focusable="false"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.75"
+              >
+                <path
+                  d="M7.5 3h6l3 3v12.75a1.5 1.5 0 0 1-1.5 1.5H7.5a1.5 1.5 0 0 1-1.5-1.5V4.5A1.5 1.5 0 0 1 7.5 3z"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <path d="M13.5 3v3h3" stroke-linecap="round" stroke-linejoin="round" />
+                <path d="M9 11.25h6" stroke-linecap="round" stroke-linejoin="round" />
+                <path d="M9 14.25h6" stroke-linecap="round" stroke-linejoin="round" />
+                <path d="M9 17.25h3.75" stroke-linecap="round" stroke-linejoin="round" />
+              </svg>
+            </span>
+            <span class="hero__resource-info">
+              <span class="hero__resource-label">Résumé library</span>
+              <span class="hero__resource-subtitle">Open tailored CVs instantly</span>
+            </span>
+          </a>
+        </div>
         <div class="hero__meta">
           <span>Last refreshed: <strong id="last-updated">—</strong></span>
           <span>Auto-refreshes every 3 hours to keep the shortlist current.</span>
         </div>
         <div class="hero__actions">
-          <a class="hero__action" href="resumes.html">Open résumé library</a>
           <a class="hero__action" href="cover-letter.html">Open cover-letter studio</a>
-          
+          <a class="hero__action" href="resumes.html">Open résumé library</a>
+
           <button type="button" class="hero__action theme-toggle" id="theme-toggle" title="Toggle dark mode">
             <span class="theme-toggle__icon"></span>
           </button>

--- a/resumes.html
+++ b/resumes.html
@@ -21,6 +21,63 @@
           Pick the résumé that aligns with the job focus and it will launch in a new tab instantly.
           Each card highlights the impact points and skills to echo in your application.
         </p>
+        <div class="hero__resources" aria-label="Quick Pathfinder tools">
+          <a class="hero__resource-link" href="cover-letter.html">
+            <span class="hero__resource-icon" aria-hidden="true">
+              <svg
+                viewBox="0 0 24 24"
+                role="img"
+                aria-hidden="true"
+                focusable="false"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.75"
+              >
+                <path
+                  d="M3.75 6.75h16.5a.75.75 0 0 1 .75.75v9a.75.75 0 0 1-.75.75H3.75A.75.75 0 0 1 3 16.5v-9a.75.75 0 0 1 .75-.75z"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <path
+                  d="M4.5 7.5l7.5 5.25L19.5 7.5"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+              </svg>
+            </span>
+            <span class="hero__resource-info">
+              <span class="hero__resource-label">Cover-letter studio</span>
+              <span class="hero__resource-subtitle">Draft outreach with résumé context</span>
+            </span>
+          </a>
+          <a class="hero__resource-link" href="resumes.html">
+            <span class="hero__resource-icon" aria-hidden="true">
+              <svg
+                viewBox="0 0 24 24"
+                role="img"
+                aria-hidden="true"
+                focusable="false"
+                fill="none"
+                stroke="currentColor"
+                stroke-width="1.75"
+              >
+                <path
+                  d="M7.5 3h6l3 3v12.75a1.5 1.5 0 0 1-1.5 1.5H7.5a1.5 1.5 0 0 1-1.5-1.5V4.5A1.5 1.5 0 0 1 7.5 3z"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                />
+                <path d="M13.5 3v3h3" stroke-linecap="round" stroke-linejoin="round" />
+                <path d="M9 11.25h6" stroke-linecap="round" stroke-linejoin="round" />
+                <path d="M9 14.25h6" stroke-linecap="round" stroke-linejoin="round" />
+                <path d="M9 17.25h3.75" stroke-linecap="round" stroke-linejoin="round" />
+              </svg>
+            </span>
+            <span class="hero__resource-info">
+              <span class="hero__resource-label">Résumé library</span>
+              <span class="hero__resource-subtitle">Open tailored CVs instantly</span>
+            </span>
+          </a>
+        </div>
         <div class="hero__actions">
           <a class="hero__action" href="index.html">Back to job links</a>
           <a class="hero__action" href="cover-letter.html">Open cover-letter studio</a>


### PR DESCRIPTION
## Summary
- add quick-access icon links for the cover-letter studio and résumé library on the hero of each page
- reorder the job links hero actions so the cover-letter entry appears before the résumé link
- style the new icon cards with hover states and dark mode support

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d353ea53088329ba1689c232399615