### PR TITLE
Reorganize navigation and surface cover letter cues

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -106,9 +106,19 @@ a:focus {
   display: flex;
   align-items: center;
   justify-content: flex-end;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+}
+
+.hero__quick-links-grid {
+  display: grid;
   gap: 0.65rem;
-  flex: 0 0 auto;
-  min-width: 240px;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  flex: 1 1 260px;
+}
+
+.hero__quick-links-grid .hero__quick-link {
+  width: 100%;
 }
 
 .hero__quick-links a,
@@ -180,6 +190,11 @@ a:focus {
 
   .hero__quick-links {
     justify-content: flex-start;
+  }
+
+  .hero__quick-links-grid {
+    grid-template-columns: minmax(0, 1fr);
+    width: 100%;
   }
 }
 

--- a/cover-letter.html
+++ b/cover-letter.html
@@ -25,22 +25,24 @@
             </p>
           </div>
           <nav class="hero__quick-links" aria-label="Primary navigation">
-            <a
-              class="hero__quick-link"
-              href="https://github.com/data614/pathfinder"
-              target="_blank"
-              rel="noopener noreferrer"
-              >Github</a
-            >
-            <a class="hero__quick-link" href="cover-letter.html" aria-current="page">Cover Letter Studio</a>
-            <a class="hero__quick-link" href="resumes.html">Resume Library</a>
-            <a
-              class="hero__quick-link"
-              href="https://app.netlify.com/teams/contact-ucroaay/projects"
-              target="_blank"
-              rel="noopener noreferrer"
-              >Deploy</a
-            >
+            <div class="hero__quick-links-grid">
+              <a
+                class="hero__quick-link"
+                href="https://github.com/data614/pathfinder"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Github</a
+              >
+              <a class="hero__quick-link" href="cover-letter.html" aria-current="page">Cover Letter Studio</a>
+              <a class="hero__quick-link" href="resumes.html">Resume Library</a>
+              <a
+                class="hero__quick-link"
+                href="https://app.netlify.com/teams/contact-ucroaay/projects"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Deploy</a
+              >
+            </div>
             <button
               type="button"
               class="hero__quick-link hero__quick-link--icon theme-toggle"

--- a/index.html
+++ b/index.html
@@ -20,36 +20,32 @@
             <p class="hero__eyebrow">Daily starting point</p>
             <h1>Pathfinder job links</h1>
             <p class="hero__subtitle">
-              Open <a
-                href="https://github.com/data614/pathfinder"
-                target="_blank"
-                rel="noopener noreferrer"
-                >the Github Project</a
-              >
-              and jump straight into curated analytics, sales, and customer success searches across Sydney, Melbourne.
-              Each visit surfaces the top 20 links and the résumé to lead with. Need a quick route to shared assets?
+              Track curated analytics, sales, and customer success searches across Sydney and Melbourne as they refresh
+              through the day. Need a quick route to shared assets?
               <a href="https://onedrive.live.com" target="_blank" rel="noopener noreferrer"
                 >Open the OneDrive shortcuts</a
               >.
             </p>
           </div>
           <nav class="hero__quick-links" aria-label="Primary navigation">
-            <a
-              class="hero__quick-link"
-              href="https://github.com/data614/pathfinder"
-              target="_blank"
-              rel="noopener noreferrer"
-              >Github</a
-            >
-            <a class="hero__quick-link" href="cover-letter.html">Cover Letter Studio</a>
-            <a class="hero__quick-link" href="resumes.html">Resume Library</a>
-            <a
-              class="hero__quick-link"
-              href="https://app.netlify.com/teams/contact-ucroaay/projects"
-              target="_blank"
-              rel="noopener noreferrer"
-              >Deploy</a
-            >
+            <div class="hero__quick-links-grid">
+              <a
+                class="hero__quick-link"
+                href="https://github.com/data614/pathfinder"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Github</a
+              >
+              <a class="hero__quick-link" href="cover-letter.html">Cover Letter Studio</a>
+              <a class="hero__quick-link" href="resumes.html">Resume Library</a>
+              <a
+                class="hero__quick-link"
+                href="https://app.netlify.com/teams/contact-ucroaay/projects"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Deploy</a
+              >
+            </div>
             <button
               type="button"
               class="hero__quick-link hero__quick-link--icon theme-toggle"
@@ -66,7 +62,6 @@
         </div>
         <div class="hero__actions">
           <a class="hero__action" href="cover-letter.html">Open cover-letter studio</a>
-          <a class="hero__action" href="resumes.html">Open résumé library</a>
         </div>
       </div>
     </header>
@@ -108,8 +103,8 @@
         </ul>
       </section>
       <p>
-         update the résumé bullet that best matches the job focus before applying. This page
-        keeps the latest searches in one place so you can execute fast.
+        Update the résumé bullet that best matches the job focus before applying. This page keeps the latest searches in
+        one place so you can execute fast.
       </p>
     </footer>
     <script src="assets/resumes.js" defer></script>

--- a/resumes.html
+++ b/resumes.html
@@ -25,22 +25,24 @@
             </p>
           </div>
           <nav class="hero__quick-links" aria-label="Primary navigation">
-            <a
-              class="hero__quick-link"
-              href="https://github.com/data614/pathfinder"
-              target="_blank"
-              rel="noopener noreferrer"
-              >Github</a
-            >
-            <a class="hero__quick-link" href="cover-letter.html">Cover Letter Studio</a>
-            <a class="hero__quick-link" href="resumes.html" aria-current="page">Resume Library</a>
-            <a
-              class="hero__quick-link"
-              href="https://app.netlify.com/teams/contact-ucroaay/projects"
-              target="_blank"
-              rel="noopener noreferrer"
-              >Deploy</a
-            >
+            <div class="hero__quick-links-grid">
+              <a
+                class="hero__quick-link"
+                href="https://github.com/data614/pathfinder"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Github</a
+              >
+              <a class="hero__quick-link" href="cover-letter.html">Cover Letter Studio</a>
+              <a class="hero__quick-link" href="resumes.html" aria-current="page">Resume Library</a>
+              <a
+                class="hero__quick-link"
+                href="https://app.netlify.com/teams/contact-ucroaay/projects"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Deploy</a
+              >
+            </div>
             <button
               type="button"
               class="hero__quick-link hero__quick-link--icon theme-toggle"
@@ -59,6 +61,60 @@
     </header>
 
     <main class="layout">
+      <section class="cover-letter-bubbles" aria-label="Cover-letter refresh focus">
+        <h3>Cover-letter refresh cues</h3>
+        <div class="cover-letter-bubbles__grid">
+          <article class="cover-letter-bubble">
+            <h4>Data Engineer cover letter</h4>
+            <p>Update these talking points when you tailor the outreach:</p>
+            <ul>
+              <li>Swap in the employer's data stack and quote the pipeline scale or latency targets from the job ad.</li>
+              <li>Reference one automation or integration win that mirrors their tooling or cloud preferences.</li>
+              <li>Close with a sentence that links your grant or delivery metrics to the team charter.</li>
+            </ul>
+            <a
+              class="cover-letter-bubble__link"
+              href="https://1drv.ms/w/c/da864a40ece446cd/Edhv_-X7tS9Hg_IEQMMnGGQB_fIPr_DnHX-WbxAiXvmf3g?e=DhP5p8"
+              target="_blank"
+              rel="noopener noreferrer"
+              >Open template</a
+            >
+          </article>
+          <article class="cover-letter-bubble">
+            <h4>Data Administrator cover letter</h4>
+            <p>Focus on these edits for data governance and admin roles:</p>
+            <ul>
+              <li>Align the opening paragraph with the stewardship, cataloguing, or SQL ownership outlined in the post.</li>
+              <li>Replace project names with the CRM, ERP, or compliance platforms the employer lists.</li>
+              <li>Highlight one controls or audit improvement that matches their risk or reporting priorities.</li>
+            </ul>
+            <a
+              class="cover-letter-bubble__link"
+              href="https://1drv.ms/w/c/da864a40ece446cd/Ed4Mq3WvwDlMq99ROTkmEjcBi2SIU3z3JZnjHuN-HTPyJA?e=u3DVlo"
+              target="_blank"
+              rel="noopener noreferrer"
+              >Open template</a
+            >
+          </article>
+          <article class="cover-letter-bubble">
+            <h4>Software sales letter</h4>
+            <p>Use these refresh cues when pitching SaaS or platform products:</p>
+            <ul>
+              <li>Lead with an outreach or pipeline metric that quantifies your ARR or revenue impact.</li>
+              <li>Mirror the prospecting motions, demo flow, or ICP priorities the employer highlights.</li>
+              <li>Close by tying a customer win to the territories or industries they list in the posting.</li>
+            </ul>
+            <a
+              class="cover-letter-bubble__link"
+              href="https://1drv.ms/w/c/da864a40ece446cd/Ed4Mq3WvwDlMq99ROTkmEjcBi2SIU3z3JZnjHuN-HTPyJA?e=u3DVlo"
+              target="_blank"
+              rel="noopener noreferrer"
+              >Open template</a
+            >
+          </article>
+        </div>
+      </section>
+
       <section class="resume-viewer" aria-label="Résumé library">
         <header class="resume-viewer__header">
           <div class="resume-viewer__intro">
@@ -73,59 +129,6 @@
           <div class="resume-viewer__list" id="resume-list">
             <p class="resume-viewer__empty">Loading résumé library…</p>
           </div>
-          <section class="cover-letter-bubbles" aria-label="Cover-letter refresh focus">
-            <h3>Cover-letter refresh cues</h3>
-            <div class="cover-letter-bubbles__grid">
-              <article class="cover-letter-bubble">
-                <h4>Data Engineer cover letter</h4>
-                <p>Update these talking points when you tailor the outreach:</p>
-                <ul>
-                  <li>Swap in the employer's data stack and quote the pipeline scale or latency targets from the job ad.</li>
-                  <li>Reference one automation or integration win that mirrors their tooling or cloud preferences.</li>
-                  <li>Close with a sentence that links your grant or delivery metrics to the team charter.</li>
-                </ul>
-                <a
-                  class="cover-letter-bubble__link"
-                  href="https://1drv.ms/w/c/da864a40ece446cd/Edhv_-X7tS9Hg_IEQMMnGGQB_fIPr_DnHX-WbxAiXvmf3g?e=DhP5p8"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  >Open template</a
-                >
-              </article>
-              <article class="cover-letter-bubble">
-                <h4>Data Administrator cover letter</h4>
-                <p>Focus on these edits for data governance and admin roles:</p>
-                <ul>
-                  <li>Align the opening paragraph with the stewardship, cataloguing, or SQL ownership outlined in the post.</li>
-                  <li>Replace project names with the CRM, ERP, or compliance platforms the employer lists.</li>
-                  <li>Highlight one controls or audit improvement that matches their risk or reporting priorities.</li>
-                </ul>
-                <a
-                  class="cover-letter-bubble__link"
-                  href="https://1drv.ms/w/c/da864a40ece446cd/Ed4Mq3WvwDlMq99ROTkmEjcBi2SIU3z3JZnjHuN-HTPyJA?e=u3DVlo"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  >Open template</a
-                >
-              </article>
-              <article class="cover-letter-bubble">
-                <h4>Software sales letter</h4>
-                <p>Use these refresh cues when pitching SaaS or platform products:</p>
-                <ul>
-                  <li>Lead with an outreach or pipeline metric that quantifies your ARR or revenue impact.</li>
-                  <li>Mirror the prospecting motions, demo flow, or ICP priorities the employer highlights.</li>
-                  <li>Close by tying a customer win to the territories or industries they list in the posting.</li>
-                </ul>
-                <a
-                  class="cover-letter-bubble__link"
-                  href="https://1drv.ms/w/c/da864a40ece446cd/Ed4Mq3WvwDlMq99ROTkmEjcBi2SIU3z3JZnjHuN-HTPyJA?e=u3DVlo"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  >Open template</a
-                >
-              </article>
-            </div>
-          </section>
         </div>
       </section>
     </main>


### PR DESCRIPTION
## Summary
- refresh the job links hero copy and remove the résumé library quick action
- restructure the header navigation into a two-row grid across pages to tighten spacing
- move the cover-letter refresh cues to the top of the résumé library layout for faster access

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d36c1eab848329a43edd941e775b8d