### PR TITLE
Remove hero eyebrow text and navigation buttons

### DIFF
--- a/cover-letter.html
+++ b/cover-letter.html
@@ -17,7 +17,6 @@
       <div class="hero__content">
         <div class="hero__toolbar">
           <div class="hero__title-group">
-            <p class="hero__eyebrow">Pathfinder toolkit</p>
             <h1>Cover-letter drafting studio</h1>
             <p class="hero__subtitle">
               Paste the job URL, choose the résumé to anchor the story, toggle company research, and capture preferences.
@@ -52,11 +51,6 @@
               <span class="theme-toggle__icon" aria-hidden="true"></span>
             </button>
           </nav>
-        </div>
-        <div class="hero__actions">
-          <a class="hero__action hero__action--secondary" href="index.html"
-            >← Back to job links</a
-          >
         </div>
       </div>
     </header>

--- a/index.html
+++ b/index.html
@@ -17,7 +17,6 @@
       <div class="hero__content">
         <div class="hero__toolbar">
           <div class="hero__title-group">
-            <p class="hero__eyebrow">Daily starting point</p>
             <h1>Pathfinder job links</h1>
             <p class="hero__subtitle">
               Track curated analytics, sales, and customer success searches across Sydney and Melbourne as they refresh

--- a/resumes.html
+++ b/resumes.html
@@ -17,7 +17,6 @@
       <div class="hero__content">
         <div class="hero__toolbar">
           <div class="hero__title-group">
-            <p class="hero__eyebrow">Résumé hub</p>
             <h1>CV and Cover Letter Library</h1>
             <p class="hero__subtitle">
               Browse the latest CVs alongside cover-letter refresh cues for analytics and data operations roles. Launch each
@@ -52,10 +51,6 @@
               <span class="theme-toggle__icon" aria-hidden="true"></span>
             </button>
           </nav>
-        </div>
-        <div class="hero__actions">
-          <a class="hero__action" href="index.html">Back to job links</a>
-          <a class="hero__action" href="cover-letter.html">Open cover-letter studio</a>
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Summary
- remove the hero eyebrow labels from the hero sections on the index, resumes, and cover letter pages
- drop the hero action buttons that linked back to job links and the cover letter studio where requested

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d36f0f28b48329a9ae8870db696d3a