### PR TITLE
Make cover letter titles open templates

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -842,6 +842,22 @@ a:focus {
   font-size: 1.05rem;
 }
 
+.cover-letter-bubble__title-link {
+  color: inherit;
+  text-decoration: none;
+  transition: color 160ms ease, text-decoration 160ms ease;
+}
+
+.cover-letter-bubble__title-link:hover,
+.cover-letter-bubble__title-link:focus-visible {
+  color: var(--accent);
+  text-decoration: underline;
+}
+
+.cover-letter-bubble__title-link:focus-visible {
+  outline-offset: 4px;
+}
+
 .cover-letter-bubble p {
   margin: 0;
   font-size: 0.95rem;
@@ -854,34 +870,6 @@ a:focus {
   display: grid;
   gap: 0.5rem;
   font-size: 0.95rem;
-}
-
-.cover-letter-bubble__link {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 0.5rem 1.05rem;
-  border-radius: 999px;
-  background: var(--accent);
-  color: #f8fafc;
-  font-weight: 600;
-  font-size: 0.85rem;
-  text-decoration: none;
-  box-shadow: 0 12px 24px rgba(37, 99, 235, 0.25);
-  transition: transform 160ms ease, box-shadow 160ms ease, background 160ms ease;
-}
-
-.cover-letter-bubble__link:hover,
-.cover-letter-bubble__link:focus-visible {
-  text-decoration: none;
-  transform: translateY(-1px);
-  background: #1d4ed8;
-  box-shadow: 0 16px 28px rgba(37, 99, 235, 0.35);
-}
-
-.cover-letter-bubble__link:focus-visible {
-  outline: none;
-  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.4), 0 16px 28px rgba(37, 99, 235, 0.35);
 }
 
 .resume-card {
@@ -1749,8 +1737,9 @@ html.dark-mode .cover-letter-bubble {
   box-shadow: inset 0 1px 0 rgba(148, 163, 184, 0.22);
 }
 
-html.dark-mode .cover-letter-bubble__link {
-  box-shadow: 0 16px 32px rgba(37, 99, 235, 0.4);
+html.dark-mode .cover-letter-bubble__title-link:hover,
+html.dark-mode .cover-letter-bubble__title-link:focus-visible {
+  color: #bfdbfe;
 }
 
 html.dark-mode .resume-card {

--- a/resumes.html
+++ b/resumes.html
@@ -60,52 +60,55 @@
         <h3>Cover-letter refresh cues</h3>
         <div class="cover-letter-bubbles__grid">
           <article class="cover-letter-bubble">
-            <h4>Data Engineer cover letter</h4>
+            <h4>
+              <a
+                class="cover-letter-bubble__title-link"
+                href="https://1drv.ms/w/c/da864a40ece446cd/Edhv_-X7tS9Hg_IEQMMnGGQB_fIPr_DnHX-WbxAiXvmf3g?e=DhP5p8"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Data Engineer cover letter</a
+              >
+            </h4>
             <p>Update these talking points when you tailor the outreach:</p>
             <ul>
               <li>Swap in the employer's data stack and quote the pipeline scale or latency targets from the job ad.</li>
               <li>Reference one automation or integration win that mirrors their tooling or cloud preferences.</li>
               <li>Close with a sentence that links your grant or delivery metrics to the team charter.</li>
             </ul>
-            <a
-              class="cover-letter-bubble__link"
-              href="https://1drv.ms/w/c/da864a40ece446cd/Edhv_-X7tS9Hg_IEQMMnGGQB_fIPr_DnHX-WbxAiXvmf3g?e=DhP5p8"
-              target="_blank"
-              rel="noopener noreferrer"
-              >Open template</a
-            >
           </article>
           <article class="cover-letter-bubble">
-            <h4>Data Administrator cover letter</h4>
+            <h4>
+              <a
+                class="cover-letter-bubble__title-link"
+                href="https://1drv.ms/w/c/da864a40ece446cd/Ed4Mq3WvwDlMq99ROTkmEjcBi2SIU3z3JZnjHuN-HTPyJA?e=u3DVlo"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Data Administrator cover letter</a
+              >
+            </h4>
             <p>Focus on these edits for data governance and admin roles:</p>
             <ul>
               <li>Align the opening paragraph with the stewardship, cataloguing, or SQL ownership outlined in the post.</li>
               <li>Replace project names with the CRM, ERP, or compliance platforms the employer lists.</li>
               <li>Highlight one controls or audit improvement that matches their risk or reporting priorities.</li>
             </ul>
-            <a
-              class="cover-letter-bubble__link"
-              href="https://1drv.ms/w/c/da864a40ece446cd/Ed4Mq3WvwDlMq99ROTkmEjcBi2SIU3z3JZnjHuN-HTPyJA?e=u3DVlo"
-              target="_blank"
-              rel="noopener noreferrer"
-              >Open template</a
-            >
           </article>
           <article class="cover-letter-bubble">
-            <h4>Software sales letter</h4>
+            <h4>
+              <a
+                class="cover-letter-bubble__title-link"
+                href="https://1drv.ms/w/c/da864a40ece446cd/Ed4Mq3WvwDlMq99ROTkmEjcBi2SIU3z3JZnjHuN-HTPyJA?e=u3DVlo"
+                target="_blank"
+                rel="noopener noreferrer"
+                >Software sales letter</a
+              >
+            </h4>
             <p>Use these refresh cues when pitching SaaS or platform products:</p>
             <ul>
               <li>Lead with an outreach or pipeline metric that quantifies your ARR or revenue impact.</li>
               <li>Mirror the prospecting motions, demo flow, or ICP priorities the employer highlights.</li>
               <li>Close by tying a customer win to the territories or industries they list in the posting.</li>
             </ul>
-            <a
-              class="cover-letter-bubble__link"
-              href="https://1drv.ms/w/c/da864a40ece446cd/Ed4Mq3WvwDlMq99ROTkmEjcBi2SIU3z3JZnjHuN-HTPyJA?e=u3DVlo"
-              target="_blank"
-              rel="noopener noreferrer"
-              >Open template</a
-            >
           </article>
         </div>
       </section>


### PR DESCRIPTION
## Summary
- replace the cover-letter template buttons with links on the card titles so clicking the bold heading opens the template in a new tab
- add styling for the new title links and dark-mode hover state

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68d37466a1308329b7d869729b7100a9