### PR TITLE
Add hall of fame thank you section

### DIFF
--- a/assets/styles.css
+++ b/assets/styles.css
@@ -204,6 +204,135 @@ a:focus {
   margin: 0;
 }
 
+.hall-of-fame {
+  margin-top: clamp(1rem, 2.2vw, 1.75rem);
+  padding: 1.25rem;
+  border-radius: var(--radius-lg);
+  background: rgba(15, 23, 42, 0.16);
+  border: 1px solid rgba(224, 231, 255, 0.35);
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.18);
+}
+
+.hall-of-fame__header {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  margin-bottom: 1.1rem;
+}
+
+.hall-of-fame__header h2 {
+  margin: 0;
+  font-size: 1.25rem;
+  font-weight: 700;
+}
+
+.hall-of-fame__intro {
+  margin: 0;
+  font-size: 0.95rem;
+  line-height: 1.6;
+  color: rgba(226, 232, 240, 0.88);
+}
+
+.hall-of-fame__grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.hall-of-fame__bubble {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem 1.1rem;
+  border-radius: var(--radius-md);
+  background: rgba(248, 250, 252, 0.92);
+  color: #0f172a;
+  box-shadow: 0 10px 28px rgba(15, 23, 42, 0.18);
+  border: 1px solid rgba(15, 23, 42, 0.08);
+}
+
+.hall-of-fame__badge {
+  align-self: flex-start;
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.14);
+  color: #1d4ed8;
+  font-weight: 600;
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.hall-of-fame__badge--in-progress {
+  background: rgba(249, 115, 22, 0.16);
+  color: #ea580c;
+}
+
+.hall-of-fame__badge--target {
+  background: rgba(34, 197, 94, 0.18);
+  color: #15803d;
+}
+
+.hall-of-fame__title {
+  margin: 0;
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.hall-of-fame__title a {
+  color: inherit;
+}
+
+.hall-of-fame__summary {
+  margin: 0;
+  font-size: 0.9rem;
+  line-height: 1.5;
+  color: rgba(15, 23, 42, 0.78);
+}
+
+.hall-of-fame__skills {
+  list-style: none;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
+  padding: 0;
+  margin: 0;
+}
+
+.hall-of-fame__skills li {
+  padding: 0.25rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.12);
+  color: #1d4ed8;
+  font-size: 0.75rem;
+  font-weight: 600;
+}
+
+.hall-of-fame__links {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+}
+
+.hall-of-fame__link {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.35rem 0.7rem;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.08);
+  color: inherit;
+  font-weight: 600;
+  font-size: 0.8rem;
+}
+
+.hall-of-fame__link:hover,
+.hall-of-fame__link:focus-visible {
+  text-decoration: none;
+  background: rgba(37, 99, 235, 0.2);
+  color: #1d4ed8;
+}
+
 @media (max-width: 768px) {
   .hero__toolbar {
     flex-direction: column;
@@ -1915,6 +2044,39 @@ html.dark-mode .resume-link:hover,
 html.dark-mode .resume-link:focus {
   border-color: rgba(96, 165, 250, 0.7);
   background: rgba(37, 99, 235, 0.32);
+  color: #e0f2fe;
+}
+
+html.dark-mode .hall-of-fame {
+  background: rgba(15, 23, 42, 0.55);
+  border-color: rgba(148, 163, 184, 0.3);
+  box-shadow: 0 20px 36px rgba(2, 6, 23, 0.55);
+}
+
+html.dark-mode .hall-of-fame__bubble {
+  background: rgba(15, 23, 42, 0.75);
+  color: #e2e8f0;
+  border-color: rgba(148, 163, 184, 0.2);
+  box-shadow: 0 16px 32px rgba(2, 6, 23, 0.5);
+}
+
+html.dark-mode .hall-of-fame__summary {
+  color: rgba(226, 232, 240, 0.78);
+}
+
+html.dark-mode .hall-of-fame__skills li {
+  background: rgba(37, 99, 235, 0.24);
+  color: #bfdbfe;
+}
+
+html.dark-mode .hall-of-fame__link {
+  background: rgba(15, 23, 42, 0.55);
+  color: #bfdbfe;
+}
+
+html.dark-mode .hall-of-fame__link:hover,
+html.dark-mode .hall-of-fame__link:focus-visible {
+  background: rgba(37, 99, 235, 0.35);
   color: #e0f2fe;
 }
 

--- a/index.html
+++ b/index.html
@@ -37,13 +37,6 @@
               >
               <a class="hero__quick-link" href="cover-letter.html">Cover Letter Studio</a>
               <a class="hero__quick-link" href="resumes.html">Resume Library</a>
-              <a
-                class="hero__quick-link"
-                href="https://app.netlify.com/teams/contact-ucroaay/projects"
-                target="_blank"
-                rel="noopener noreferrer"
-                >Deploy</a
-              >
             </div>
             <button
               type="button"
@@ -54,6 +47,137 @@
               <span class="theme-toggle__icon" aria-hidden="true"></span>
             </button>
           </nav>
+          <section class="hall-of-fame" aria-label="Hall of Fame">
+            <header class="hall-of-fame__header">
+              <h2>Hall of Fame</h2>
+              <p class="hall-of-fame__intro">
+                Thank you notes from recent wins. Track the job links, the must-have skills, and the resume or cover used for
+                each milestone.
+              </p>
+            </header>
+            <div class="hall-of-fame__grid">
+              <article class="hall-of-fame__bubble">
+                <div class="hall-of-fame__badge">Phone interview secured</div>
+                <h3 class="hall-of-fame__title">
+                  <a
+                    href="https://www.linkedin.com/jobs/view/sales-development-representative-anz-new-business-at-sitecore-4298376894/?originalSubdomain=au"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >Sales Development Representative ANZ – Sitecore</a
+                  >
+                </h3>
+                <p class="hall-of-fame__summary">
+                  Highlighted relentless outbound energy and tailored discovery that matched Sitecore's hunt for a fearless
+                  SDR.
+                </p>
+                <ul class="hall-of-fame__skills" aria-label="Key skills showcased">
+                  <li>Outbound prospecting</li>
+                  <li>Pipeline generation</li>
+                  <li>High-volume calling</li>
+                  <li>Collaborative feedback loops</li>
+                </ul>
+                <div class="hall-of-fame__links">
+                  <a
+                    class="hall-of-fame__link"
+                    href="https://www.linkedin.com/jobs/view/sales-development-representative-anz-new-business-at-sitecore-4298376894/?originalSubdomain=au"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >View job description</a
+                  >
+                  <a
+                    class="hall-of-fame__link"
+                    href="https://1drv.ms/w/c/da864a40ece446cd/EU9bgrljZxREt4hdbvJIETABAazLTskZWcVthvJPX4RjIg?e=PrZ6Xn"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >Review applied cover</a
+                  >
+                </div>
+              </article>
+
+              <article class="hall-of-fame__bubble">
+                <div class="hall-of-fame__badge hall-of-fame__badge--in-progress">Pipeline ready</div>
+                <h3 class="hall-of-fame__title">
+                  <a
+                    href="https://www.seek.com.au/job/86876437?ref=applied"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >BI Developer – Hume</a
+                  >
+                </h3>
+                <p class="hall-of-fame__summary">
+                  Framed the analytics automation story around the greenfield build of Hume's reporting stack and training
+                  remit.
+                </p>
+                <ul class="hall-of-fame__skills" aria-label="Key skills showcased">
+                  <li>Power BI dashboards</li>
+                  <li>Azure data services</li>
+                  <li>SQL modelling</li>
+                  <li>ETL orchestration</li>
+                </ul>
+                <div class="hall-of-fame__links">
+                  <a
+                    class="hall-of-fame__link"
+                    href="https://www.seek.com.au/job/86876437?ref=applied"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >View job description</a
+                  >
+                  <a
+                    class="hall-of-fame__link"
+                    href="https://1drv.ms/w/c/da864a40ece446cd/EQjQ4wDZMxxMsLPrcitR_YQBdUWL7iB8EzGHL_-tQkxfNw?e=T4LPWN"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >See resume focus</a
+                  >
+                  <a
+                    class="hall-of-fame__link"
+                    href="https://1drv.ms/w/c/da864a40ece446cd/ETqcLDJX4KZJtt7h_EXzsasB2gITP96WIoupAF8hFIV-nw?e=TQwUOY"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >Cover letter reference</a
+                  >
+                </div>
+              </article>
+
+              <article class="hall-of-fame__bubble">
+                <div class="hall-of-fame__badge hall-of-fame__badge--target">Next up</div>
+                <h3 class="hall-of-fame__title">
+                  <a
+                    href="https://www.linkedin.com/jobs/view/4289426852/?refId=0e12481f-4abd-4a6d-bfc1-6a33163c4590&trackingId=z1ErwG4yQQ2d6rAmCn%2BUTg%3D%3D"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >Senior Finance Sales Representative – BCR</a
+                  >
+                </h3>
+                <p class="hall-of-fame__summary">
+                  Positioning multi-lingual FX product knowledge and client relationship systems to mirror BCR's global,
+                  regulated remit.
+                </p>
+                <ul class="hall-of-fame__skills" aria-label="Key skills showcased">
+                  <li>Financial product advisory</li>
+                  <li>Client acquisition</li>
+                  <li>Regulatory awareness</li>
+                  <li>CRM precision</li>
+                </ul>
+                <div class="hall-of-fame__links">
+                  <a
+                    class="hall-of-fame__link"
+                    href="https://www.linkedin.com/jobs/view/4289426852/?refId=0e12481f-4abd-4a6d-bfc1-6a33163c4590&trackingId=z1ErwG4yQQ2d6rAmCn%2BUTg%3D%3D"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >View job description</a
+                  >
+                  <a
+                    class="hall-of-fame__link"
+                    href="https://1drv.ms/w/c/da864a40ece446cd/EQffVjK_CAdIkuUJkWpmpAYBbntWbLVErhRYszTs8rOf9A?e=mlbdEp"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    >See tailored resume</a
+                  >
+                </div>
+              </article>
+            </div>
+          </section>
         </div>
         <div class="hero__meta">
           <span>Last refreshed: <strong id="last-updated">—</strong></span>


### PR DESCRIPTION
## Summary
- replace the deploy quick link with a Hall of Fame card that highlights successful applications and assets
- add styling for the new Hall of Fame bubbles including status badges, skill tags, and responsive layout
- ensure dark mode keeps the Hall of Fame content legible with dedicated theme overrides

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68da662cbf0083298efe6dd35a09025c