### PR TITLE
Remove outdated resume library guidance

### DIFF
--- a/assets/script.js
+++ b/assets/script.js
@@ -328,7 +328,7 @@
       }
     });
     resumeListEl.replaceChildren(fragment);
-    showResumeMessage('Click a résumé title to open it in a new tab.');
+    showResumeMessage('');
   };
 
   const createJobCard = (job) => {

--- a/resumes.html
+++ b/resumes.html
@@ -57,7 +57,6 @@
 
     <main class="layout">
       <section class="cover-letter-bubbles" aria-label="Cover-letter refresh focus">
-        <h3>Cover-letter refresh cues</h3>
         <div class="cover-letter-bubbles__grid">
           <article class="cover-letter-bubble">
             <h4>
@@ -117,7 +116,6 @@
         <header class="resume-viewer__header">
           <div class="resume-viewer__intro">
             <h2>CV and Cover Letter Library</h2>
-            <p>Open the profile that matches the role focus and use the refresh cues to localise every submission.</p>
           </div>
         </header>
         <div class="resume-viewer__content">


### PR DESCRIPTION
## Summary
- remove obsolete resume library instructions from the CV and Cover Letter Library page
- clear the resume viewer notification once items are rendered so no guidance message appears

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68da693a411083299bd0e29ddebe2a4d